### PR TITLE
add default title to user story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/user-story-issue-template.md
@@ -1,10 +1,9 @@
 ---
 name: User story issue template
 about: The standard user story issue template for the project
-title: ''
+title: "User story - <brief description of story>"
 labels: user story
-assignees: ''
-
+assignees: ""
 ---
 
 ### Story


### PR DESCRIPTION
This just adds a the `User story -` as a default to the title in the issue template so that we have some consistency. 